### PR TITLE
Update README.md  (Start Übernahme Wiki -> Github)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
+Neues Zuhause unserer Planungsseite
+
 # SAP Stammtisch Frankfurt 
+![image](https://user-images.githubusercontent.com/2906185/169572009-3beb0ce0-e0c7-41e8-8b81-54f62cea7f5e.png)
+## Nächster Termin:  8. Juni 2022 ab 19:00h im ApfelweinDax 
+(Registrierungslink folgt)
+
+## Monatliches Treffen der Rhein-Main SAP Community in Frankfurt
+Unsere Stammkneipe ist der Apfelwein DAX. Hier treffen wir uns seit 2014 einmal im Monat und tauschen uns über SAP, die Arbeit und alles andere im Leben aus.
+Die COVID19 Pandemie hat uns für 2 lange Jahre in einen virtuellen Modus gebracht, aber im Sommer 2022 wollen wir wieder an unsere Tradition im ApfelweinDax anknüpfen.
+Die Treffen sind formlos ... keine Agenda,keine Folien, kein Laptop/Tablet ... einfach ein lockerer AfterWork-Modus.
+Über die aktuellen Themen rund um SAP tauschen wir uns beim Apfelwein und traditioneller Frankfurt Küche aus - rund um unseren eigenen SAPStammtisch-Bembel.
+
+
+![image](https://user-images.githubusercontent.com/2906185/169576643-a7063e09-78d6-4bc3-98a8-3458a8949b13.png)
+## Historie
+Hier sammeln wir die Termine und Erinnerungen vergangener Treffen
+
+## Weitere Eventformate der Frankfurter Community
+### SAPInsideTrack
+2015, 2016, 2017, 2018, 2019 
+organsierten wir im März einen 1-Tages Community-Driven-Event in der Tradition der weltweit stattfindenden SAPInsideTracks.
+Den bereits geplanten Termin in 2020 haben wir aufgrund der nahenden ersten COVID19-Welle absagen müssen.
+
+### SAPStammtischPlus
+Von 2017 bis 2019 veranstalteten wir einige #StammtischPLUS Treffen. 
+Da im Apfelwein DAX die Nutzung eines Beamers für die anderen Gäste irritierend wirken könnte ;-) treffen wir uns beim StammtischPLUS in den Räumlichkeiten eines einladenden Unternehmens. Die ersten 60-90 Minuten nutzen wir für Vorträge aus der Community.. fachliche Appetizer .. zu denen wir uns dann später beim Essen&Trinken austauschen können.
+


### PR DESCRIPTION
Übernahme der Informationen aus dem Wiki
   https://wiki.scn.sap.com/wiki/display/events/SAP+Stammtisch+Frankfurt
und erste Ankündigung des Termins am 8. Juni 2022